### PR TITLE
Implemented fetching of weather data from sensors closest to each fje…

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -18,3 +18,7 @@ export const fetchAllMountainPasses = () => {
 export const fetchMountainPasses = (id: string) => {
   return apiClient.get(`/mountainPass/${id}`);
 };
+
+export const fetchWeatherData = (lat: number, lon: number) => {
+  return apiClient.get(`/getCurrentWeather?lat=${lat}&lon=${lon}`)
+}

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -7,13 +7,15 @@ import {
   CardContent,
 } from "@mui/material";
 import { Thermostat, Air, Thunderstorm } from "@mui/icons-material";
+import { WeatherData } from "../utils/dataTypes";
 
 interface CameraCardProps {
   imgSrc: string;
   fjell: string;
+  weatherData: WeatherData;
 }
 
-function CameraCard({ imgSrc, fjell }: CameraCardProps) {
+function CameraCard({ imgSrc, fjell, weatherData }: CameraCardProps) {
   return (
     <Card>
       <CardMedia
@@ -27,9 +29,9 @@ function CameraCard({ imgSrc, fjell }: CameraCardProps) {
           {fjell}
         </Typography>
         <Stack direction={"row"} spacing={2}>
-          <Chip label={"2.7 C"} icon={<Thermostat />} />
-          <Chip label={"4.5 m/c"} icon={<Air />} />
-          <Chip label={"2.7 mm/t"} icon={<Thunderstorm />} />
+          {weatherData.temperature ? <Chip label={weatherData.temperature + "°C"} icon={<Thermostat />} /> : <></>}
+          {weatherData.windSpeed ? <Chip label={weatherData.windSpeed + "m/s"} icon={<Air />} /> : <></>}
+          {false ? <Chip label={"null"} icon={<Thunderstorm />} /> : <></>}
         </Stack>
       </CardContent>
     </Card>

--- a/src/utils/dataTypes.ts
+++ b/src/utils/dataTypes.ts
@@ -1,0 +1,6 @@
+
+export type WeatherData = {
+    id: string;
+    temperature: number;
+    windSpeed: number;
+}


### PR DESCRIPTION
Lagt til funksjonalitet for å hente vær data fra backend. Når man velger en fjellovergang i menyen sendes det et kall til backend om å hente værdata tilhørende den nærmeste sensoren til denne fjellovergangen. Enn så lenge er det kun temperatur og wind speed som er tilgjengelig fra backend.

- Lagt til ny funksjon i api fil for å kalle på riktig endepunkt
- Lagt til async/await func for å bruke denne funksjonen/hente data fra backend hver gang ny fjellovergang blir valgt på siden
- Laget en WeatherData type i ny dataTypes.ts fil. Vi kan vurdere å slenge alle objects/types i samme fil? Evt bli enige om best practice på det. 
- Vær dataen blir sendt inn som parametere til CameraCard komponenten.
- Lagt til slik at om det ikke finnes temperatur eller wind speed data til en spesifikk fjellovergang, vil det ikke vises i camera cardet.

Ref siste punkt: Ikke alle sensorer har all den dataen man vil ha. Det er derfor kun enn så lenge at temperatur og vind blir hentet. I tillegg er det ikke alle sensorene som har dette heller, derav funksjonaliteten for å kun vise dataen om den finnes.