### PR TITLE
Ytelses forbedring

### DIFF
--- a/src/components/MountainPassCard.tsx
+++ b/src/components/MountainPassCard.tsx
@@ -4,26 +4,28 @@ import { MountainPassData } from "../utils/mountainPassTypes";
 import PrognoseCard from "./PrognoseCard";
 import CardStats from "./CardStats";
 import { predictions } from "../utils/PredictionTypes";
+import { Dispatch, SetStateAction } from "react";
 
 interface MountainPassCardProps {
   data: MountainPassData;
-  handleClick: (id: number, open: boolean, index: number) => void;
-  index: number;
-  openIndex: number | null;
   prediction: predictions[];
   predictionLoading: boolean;
+  selectPass: Dispatch<SetStateAction<MountainPassData | null>>;
+  selectedPass: MountainPassData | null;
 }
 
 function MountainPassCard({
   data,
-  handleClick,
-  index,
-  openIndex,
   prediction,
   predictionLoading,
+  selectPass,
+  selectedPass,
 }: MountainPassCardProps) {
-  const isOpen = openIndex == index;
-  const handleCardClick = () => handleClick(data.properties.id, !isOpen, index);
+  const isOpen = selectedPass?.properties.id === data.properties.id;
+  const handleCardClick = () =>
+    selectPass((prevPass) =>
+      prevPass && prevPass.properties.id === data.properties.id ? null : data
+    );
 
   return (
     <Card

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -59,6 +59,8 @@ function MapPage() {
 
   const [showAll, setShowAll] = useState<boolean>(true);
 
+  const [finishedZoom, setFinishedZoom] = useState<boolean>(false);
+
   const [loadingFjelloverganger, setLoadingFjelloverganger] =
     useState<boolean>(true);
   const [viewState, setViewState] = useState<ViewState>(initialViewState);
@@ -96,14 +98,17 @@ function MapPage() {
 
   useEffect(() => {
     if (mapRef.current) {
+      setFinishedZoom(false);
       if (selectedPass && selectedPass.properties.senter) {
         const [longitude, latitude] =
           selectedPass.properties.senter.coordinates;
-        mapRef.current.flyTo({
-          center: [longitude, latitude],
-          zoom: 10,
-          duration: 2000,
-        });
+        mapRef.current
+          .flyTo({
+            center: [longitude, latitude],
+            zoom: 10,
+            duration: 2000,
+          })
+          .once("moveend", () => setFinishedZoom(true));
       } else {
         mapRef.current.flyTo({
           center: [initialViewState.longitude, initialViewState.latitude],
@@ -181,19 +186,21 @@ function MapPage() {
                 data={mountainPassData}
                 key={mountainPassData.properties.id}
               >
-                {selectedPass && selectedPass.properties.senter && (
-                  <Marker
-                    longitude={selectedPass.properties.senter.coordinates[0]}
-                    latitude={selectedPass.properties.senter.coordinates[1]}
-                  >
-                    <CameraCard
-                      imgSrc={
-                        "https://webkamera.atlas.vegvesen.no/public/kamera?id=3000545_1"
-                      }
-                      fjell={selectedPass.properties.navn}
-                    />
-                  </Marker>
-                )}
+                {selectedPass &&
+                  finishedZoom &&
+                  selectedPass.properties.senter && (
+                    <Marker
+                      longitude={selectedPass.properties.senter.coordinates[0]}
+                      latitude={selectedPass.properties.senter.coordinates[1]}
+                    >
+                      <CameraCard
+                        imgSrc={
+                          "https://webkamera.atlas.vegvesen.no/public/kamera?id=3000545_1"
+                        }
+                        fjell={selectedPass.properties.navn}
+                      />
+                    </Marker>
+                  )}
                 <Layer
                   id={`route-layer-${mountainPassData.properties.id}`}
                   type="line"

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -79,13 +79,13 @@ function MapPage() {
   useEffect(() => {
     const getData = async () => {
       try {
-        const result = await fetchPrediction();
-        setPrediction(result.data);
-        setPredictionLoading(false);
-
         const pass = await fetchAllMountainPasses();
         setIndividualGeojsons(buildIndividualGeoJson(pass.data));
         setLoadingFjelloverganger(false);
+
+        const result = await fetchPrediction();
+        setPrediction(result.data);
+        setPredictionLoading(false);
       } catch (error) {
         console.log(`Error: ${error}`);
       }


### PR DESCRIPTION
Primært jobbet i map-page for å minimere loading tid og fikse hakkete zoom. 

- i stedet for å sende ved handleclick, sender jeg en state som tar vare på den valgte fjellovergangen, slik at når en fjellovergang blir klikket på, settes den til valgt overgang. Dette er en mer declarative approach som bla kutter ned på state bruk
- endret rekkefølge på api kall - fjelloverganger kalles før prediction.
- lagt til en states som holder styr på når zoomen er ferdig og viser cameraCard pop-upen først etter flyto er ferdig. 