### PR TITLE
Added Dockerfile to build a container for prod deployment, and change…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:18
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+RUN npm install -g serve
+
+EXPOSE 8080
+
+CMD ["serve", "-s", "build", "-l", "8080"]

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const apiClient = axios.create({
-  baseURL: "http://localhost:8080/api",
+  baseURL: process.env.REACT_APP_API_BASE_URL + "/api",
   headers: {
     "Content-Type": "application/json",
   },


### PR DESCRIPTION
Klargjort frontend til deployment i Google Cloud. 

- Lagt til en Dockerfile som setter opp applikasjonen i en container som kan sendes til Google cloud fro deployment.
- Endret api url til å være en env variabel slik at man man bruker riktig backend i forhold til om man er local eller prod. 

LOKALT: 
I .env filen din, legg til:
REACT_APP_API_BASE_URL="http://localhost:8080"