### PR TITLE
Passability update

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -23,6 +23,6 @@ export const fetchWeatherData = (lat: number, lon: number) => {
   return apiClient.get(`/getCurrentWeather?lat=${lat}&lon=${lon}`);
 };
 
-export const fetchPassabillity = () => {
-  return apiClient.get("/getCurrentPassability");
+export const fetchPassabillity = (id: number) => {
+  return apiClient.get(`/getCurrentPassability/${id}`);
 };

--- a/src/components/MountainPassCard.tsx
+++ b/src/components/MountainPassCard.tsx
@@ -5,7 +5,7 @@ import PrognoseCard from "./PrognoseCard";
 import CardStats from "./CardStats";
 import { predictions } from "../types/PredictionTypes";
 import { Dispatch, SetStateAction } from "react";
-import { fetchPrediction } from "../api/api";
+import { fetchPassabillity, fetchPrediction } from "../api/api";
 import useFetch from "../hooks/useFetch";
 
 interface MountainPassCardProps {
@@ -32,6 +32,14 @@ function MountainPassCard({
     error: predictionError,
     loading: predictionLoading,
   } = useFetch(() => fetchPrediction(data.properties.id.toString()));
+
+  const {
+    data: passability,
+    error: passabilityError,
+    loading: passabilityLoading,
+  } = useFetch(() => fetchPassabillity(data.properties.id));
+
+  const isMountainPassClosed = passability?.passability;
 
   return (
     <Card
@@ -68,9 +76,9 @@ function MountainPassCard({
             }
           />
           <Chip
-            icon={<Circle color={closed ? "error" : "success"} />}
-            label={closed ? "Stengt" : "Åpen"}
-            sx={{ backgroundColor: closed ? "#693030" : "#306948" }}
+            icon={<Circle color={isMountainPassClosed ? "error" : "success"} />}
+            label={isMountainPassClosed ? "Stengt" : "Åpen"}
+            sx={{ backgroundColor: isMountainPassClosed ? "#693030" : "#306948" }}
           />
         </Box>
       </Box>

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -41,12 +41,6 @@ function MapPage() {
     loading: loadingFjelloverganger,
   } = useFetch(fetchAllMountainPasses, buildIndividualGeoJson);
 
-  const {
-    data: passability,
-    error: passabilityError,
-    loading: passabilityLoading,
-  } = useFetch(fetchPassabillity);
-
   const { data: cameraData } = useFetch(fetchAllCameras);
 
   const [showAll, setShowAll] = useState<boolean>(true);
@@ -160,7 +154,6 @@ function MapPage() {
                   key={mountainPassData.properties.id}
                   selectPass={setSelectedPass}
                   selectedPass={selectedPass}
-                  closed={passability?.passability}
                 />
               ))
             )}

--- a/src/types/PredictionTypes.ts
+++ b/src/types/PredictionTypes.ts
@@ -3,9 +3,3 @@ export type predictions = {
   prediction: number;
   prediction_time: string;
 };
-
-export type passabillity = {
-  time: string;
-  passability: boolean;
-  coordinates: number[];
-};

--- a/src/types/mountainPassTypes.ts
+++ b/src/types/mountainPassTypes.ts
@@ -26,3 +26,8 @@ export type cameraData = {
   kameraId: string;
   sted: string;
 };
+
+export type Passabillity = {
+  id: number;
+  passability: boolean;
+};


### PR DESCRIPTION
Oppdaterte status tagen på fjellovergsangene til å vise om fjellovergangene er åpne eller stengt. 

- Flyttet Passability type til MountainPass types og endret objektet til å kun ha id og passability. Grunnen til dette er at jeg tenkte at passability er faktisk data tilhørende til hver enkelt fjellovergang. Og passability typen trenger vel kun å ha de to data feltene.
- Flyttet passability logikken til MopuntainPassCard komponenten så getPassability endepunktet kan kalles på med den respektive fjellovergang id'en