### PR TITLE
Added link to grafana dashboard in prognosecard

### DIFF
--- a/src/components/MountainPassCard.tsx
+++ b/src/components/MountainPassCard.tsx
@@ -100,7 +100,7 @@ function MountainPassCard({
         <Divider sx={{ marginTop: 2, opacity: 0.8 }} />
 
         <Typography variant="h6">Prognose</Typography>
-        <PrognoseCard predictions={prediction} loading={predictionLoading} />
+        <PrognoseCard id={data.properties.id} predictions={prediction} loading={predictionLoading} />
       </Collapse>
     </Card>
   );

--- a/src/components/PrognoseCard.tsx
+++ b/src/components/PrognoseCard.tsx
@@ -1,11 +1,13 @@
 import { Divider, Typography, Stack, Chip, Skeleton } from "@mui/material";
 import { predictions } from "../types/PredictionTypes";
 import { isToday, isTomorrow } from "../utils/dateCheckers";
+import LaunchOutlinedIcon from '@mui/icons-material/LaunchOutlined';
 
 const LAV = 0.2;
 const MEDIUM = 0.5;
 
 interface ProgniseCardProps {
+  id: number;
   predictions: predictions[];
   loading: boolean;
 }
@@ -20,13 +22,32 @@ const getPredictionColor = (prediction: number): string => {
   }
 };
 
-function PrognoseCard({ predictions, loading }: ProgniseCardProps) {
+function PrognoseCard({ id, predictions, loading }: ProgniseCardProps) {
 
   return (
     <Stack spacing={2}>
       <Typography>Risiko for stenging på grunn av vær</Typography>
 
-      
+      {id===638645987 &&
+        <Typography
+          component="a"
+          href="https://gyda1210.grafana.net/d/fdyg4nqolil1ce/svv-fjelloverganger?from=2022-10-01T00:00:00.000Z&to=2023-05-31T23:00:00.000Z&timezone=utc&refresh="
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{
+            fontWeight: "bold",
+            textDecoration: "none",
+            color: "primary.main",
+            display: "inline-flex",
+            "&:hover": {
+              color: "secondary.main",
+            },
+          }}
+        >
+          <LaunchOutlinedIcon sx={{ fontSize: 22, mr: 0.5 }} />
+          Detaljert visning
+        </Typography>
+      }
 
       {loading ? (
         <Skeleton variant="rounded" width={210} height={300} />


### PR DESCRIPTION
Lagt til link i PrognoseCard til grafana dashboard. Ettersom det kun er laget dashboard for Saltfjellet, er det direkte link til dette dashboardet. Det er hardkodet med id'en til saltfjellet for å kun vise linken i saltfjellet kortet. Ikke optimalt, men tenker det funker nå enn så lenge hvertfall.