### PR TITLE
Add passability colored map path

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -12,7 +12,7 @@ export const fetchPrediction = (id: string) => {
 };
 
 export const fetchAllMountainPasses = () => {
-  return apiClient.get("/getRelevantMountainPasses");
+  return apiClient.get("/getRelevantMountainPassesWithPassability");
 };
 
 export const fetchMountainPasses = (id: string) => {

--- a/src/components/MountainPassCard.tsx
+++ b/src/components/MountainPassCard.tsx
@@ -3,7 +3,7 @@ import { KeyboardArrowRight, Circle } from "@mui/icons-material";
 import { MountainPassData } from "../types/mountainPassTypes";
 import PrognoseCard from "./PrognoseCard";
 import { Dispatch, SetStateAction } from "react";
-import { fetchPassabillity, fetchPrediction } from "../api/api";
+import { fetchPrediction } from "../api/api";
 import useFetch from "../hooks/useFetch";
 
 interface MountainPassCardProps {
@@ -29,13 +29,7 @@ function MountainPassCard({
     loading: predictionLoading,
   } = useFetch(() => fetchPrediction(data.properties.id.toString()));
 
-  const {
-    data: passability,
-    error: passabilityError,
-    loading: passabilityLoading,
-  } = useFetch(() => fetchPassabillity(data.properties.id));
-
-  const isMountainPassClosed = passability?.passability;
+  const isMountainPassClosed = data.properties.passability;
 
   return (
     <Card
@@ -71,19 +65,13 @@ function MountainPassCard({
               data.properties.veiKategori + "." + data.properties.veiNummer
             }
           />
-          {passabilityLoading ? (
-            <Chip icon={<Circle />} label={"Loading"} />
-          ) : (
-            <Chip
-              icon={
-                <Circle color={isMountainPassClosed ? "error" : "success"} />
-              }
-              label={isMountainPassClosed ? "Stengt" : "Åpen"}
-              sx={{
-                backgroundColor: isMountainPassClosed ? "#693030" : "#306948",
-              }}
-            />
-          )}
+          <Chip
+            icon={<Circle color={isMountainPassClosed ? "error" : "success"} />}
+            label={isMountainPassClosed ? "Stengt" : "Åpen"}
+            sx={{
+              backgroundColor: isMountainPassClosed ? "#693030" : "#306948",
+            }}
+          />
         </Box>
       </Box>
 

--- a/src/components/MountainpassList.tsx
+++ b/src/components/MountainpassList.tsx
@@ -1,4 +1,3 @@
-import { Skeleton } from "@mui/material";
 import { MountainPassData } from "../types/mountainPassTypes";
 import MountainPassCard from "./MountainPassCard";
 

--- a/src/components/map/CameraCard.tsx
+++ b/src/components/map/CameraCard.tsx
@@ -8,7 +8,7 @@ import {
   Skeleton,
 } from "@mui/material";
 import { Thermostat, Air, Thunderstorm } from "@mui/icons-material";
-import { WeatherData } from "../types/dataTypes";
+import { WeatherData } from "../../types/dataTypes";
 
 const cameras: { [id: number]: string } = {
   638645987: "1829006_2",

--- a/src/components/map/MountainMap.tsx
+++ b/src/components/map/MountainMap.tsx
@@ -1,8 +1,9 @@
 import Map, { Layer, Source, ViewState, Marker } from "react-map-gl";
 
-import { MountainPassData } from "../types/mountainPassTypes";
-import { WeatherData } from "../types/dataTypes";
+import { MountainPassData } from "../../types/mountainPassTypes";
+import { WeatherData } from "../../types/dataTypes";
 import CameraCard from "./CameraCard";
+import MountainPassMapLines from "./MountainPassMapLines";
 
 interface MountainMapProps {
   viewState: ViewState;
@@ -10,7 +11,8 @@ interface MountainMapProps {
   darkMode: boolean;
   mapRef: React.MutableRefObject<any>;
   showAll: boolean;
-  individualGeojsons: MountainPassData[] | null;
+  mountainpassData: MountainPassData[] | null;
+  mountainpassLoading: boolean;
   selectedPass: MountainPassData | null;
   finishedZoom: boolean;
   weatherData: WeatherData | null;
@@ -28,7 +30,8 @@ function MountainMap({
   darkMode,
   mapRef,
   showAll,
-  individualGeojsons,
+  mountainpassData,
+  mountainpassLoading,
   selectedPass,
   finishedZoom,
   weatherData,
@@ -45,7 +48,7 @@ function MountainMap({
       style={{ flex: "3", height: "100%", width: "100%" }}
     >
       {showAll ? (
-        individualGeojsons?.map((mountainPassData: MountainPassData) => (
+        mountainpassData?.map((mountainPassData: MountainPassData) => (
           <Source
             id={mountainPassData.properties.id.toString()}
             type="geojson"
@@ -66,15 +69,10 @@ function MountainMap({
                 />
               </Marker>
             )}
-            <Layer
-              id={`route-layer-${mountainPassData.properties.id}`}
-              type="line"
-              layout={{ "line-cap": "round", "line-join": "round" }}
-              paint={
-                mountainPassData.properties.strekningsType === "Fjellovergang"
-                  ? { "line-color": "#FF9999", "line-width": 2 }
-                  : { "line-color": "#99CCFF", "line-width": 2 }
-              }
+            <MountainPassMapLines
+              mountainPassId={mountainPassData.properties.id}
+              isMountainPassClosed={mountainPassData.properties.passability}
+              loading={mountainpassLoading}
             />
           </Source>
         ))

--- a/src/components/map/MountainPassMapLines.tsx
+++ b/src/components/map/MountainPassMapLines.tsx
@@ -1,0 +1,32 @@
+import { Layer } from "react-map-gl";
+
+interface MountainPassMapLinesProps {
+  mountainPassId: number;
+  isMountainPassClosed: boolean;
+  loading: boolean;
+}
+
+function MountainPassMapLines({
+  mountainPassId,
+  isMountainPassClosed,
+  loading,
+}: MountainPassMapLinesProps) {
+  return (
+    <Layer
+      id={`route-layer-${mountainPassId}`}
+      source={mountainPassId.toString()}
+      type="line"
+      layout={{ "line-cap": "round", "line-join": "round" }}
+      paint={{
+        "line-width": 3,
+        "line-color": loading
+          ? "#888888"
+          : isMountainPassClosed
+            ? "#d65454"
+            : "#3bc474",
+      }}
+    />
+  );
+}
+
+export default MountainPassMapLines;

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -8,11 +8,7 @@ import CssBaseline from "@mui/material/CssBaseline";
 
 import { WeatherData } from "../types/dataTypes";
 
-import {
-  fetchAllMountainPasses,
-  fetchPassabillity,
-  fetchWeatherData,
-} from "../api/api";
+import { fetchAllMountainPasses, fetchWeatherData } from "../api/api";
 import useFetch from "../hooks/useFetch";
 import { buildIndividualGeoJson } from "../utils/buildGeoJson";
 

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -8,13 +8,17 @@ import CssBaseline from "@mui/material/CssBaseline";
 
 import { WeatherData } from "../types/dataTypes";
 
-import { fetchAllMountainPasses, fetchWeatherData } from "../api/api";
+import {
+  fetchAllMountainPasses,
+  fetchPassabillity,
+  fetchWeatherData,
+} from "../api/api";
 import useFetch from "../hooks/useFetch";
 import { buildIndividualGeoJson } from "../utils/buildGeoJson";
 
 import { MountainPassData } from "../types/mountainPassTypes";
 import MountainPassList from "../components/MountainpassList";
-import MountainMap from "../components/MountainMap";
+import MountainMap from "../components/map/MountainMap";
 import { ViewState } from "react-map-gl";
 
 const initialViewState: ViewState = {
@@ -150,7 +154,8 @@ function MapPage() {
           darkMode={darkMode}
           mapRef={mapRef}
           showAll={showAll}
-          individualGeojsons={individualGeojsons}
+          mountainpassData={individualGeojsons}
+          mountainpassLoading={loadingFjelloverganger}
           selectedPass={selectedPass}
           finishedZoom={finishedZoom}
           weatherData={weatherData}

--- a/src/types/mountainPassTypes.ts
+++ b/src/types/mountainPassTypes.ts
@@ -9,8 +9,6 @@ export interface MountainPassData {
 export type MountainPassType = {
   id: number;
   navn: string;
-  overgangsType: string;
-  antallFylker: number;
   veiKategori: string;
   veiNummer: number;
   strekningsType: string;
@@ -19,6 +17,7 @@ export type MountainPassType = {
   lokaltFra: string;
   lokaltTil: string;
   senter: GeoJSON.Point;
+  passability: boolean;
   wkt: string;
 };
 

--- a/src/utils/buildGeoJson.ts
+++ b/src/utils/buildGeoJson.ts
@@ -9,8 +9,6 @@ export const buildIndividualGeoJson = (data: any[]): MountainPassData[] => {
       properties: {
         id: feature.id,
         navn: feature.navn,
-        overgangsType: feature.overgangstype,
-        antallFylker: feature.antallFylker,
         veiKategori: feature.veiKategori,
         veiNummer: feature.veiNummer,
         strekningsType: feature.strekningsType,
@@ -19,6 +17,7 @@ export const buildIndividualGeoJson = (data: any[]): MountainPassData[] => {
         lokaltFra: feature.lokaltFra,
         lokaltTil: feature.lokaltTil,
         senter: wellknown.parse(feature.senter) as GeoJSON.Point,
+        passability: feature.passability,
         wkt: feature.wkt,
       },
     };


### PR DESCRIPTION
- Henter passability sammen med fjellovergang-data, altså oppdatert type, og api til å hente fra `getRelevantMountainPassesWithPassability `
- Rendrer farge på overgang i kart utfra fjellovergang-dataen sin passability
- MountainpassCard henter også passability fra fjellovergang-lista. 
- Sinnsykt mye kortere loading tid 🔥 🕐 

![image](https://github.com/user-attachments/assets/299f34e6-fbb1-4642-9853-6490c7e25737)
