### PR TITLE
Changed prognose satus to be with time interval

### DIFF
--- a/src/components/PrognoseCard.tsx
+++ b/src/components/PrognoseCard.tsx
@@ -1,6 +1,6 @@
 import { Divider, Typography, Stack, Chip, Skeleton } from "@mui/material";
 import { predictions } from "../types/PredictionTypes";
-import { isToday, isTomorrow } from "../utils/dateCheckers";
+import { isToday, isTomorrow, nextTimeInterval } from "../utils/dateCheckers";
 import LaunchOutlinedIcon from '@mui/icons-material/LaunchOutlined';
 
 const LAV = 0.2;
@@ -70,7 +70,7 @@ function PrognoseCard({ id, predictions, loading }: ProgniseCardProps) {
             if (isToday(prediction.datetime)) {
               return (
                 <Stack key={index} direction={"row"} spacing={7}>
-                  <Typography>{prediction.datetime.split(" ")[1]}</Typography>
+                  <Typography>{prediction.datetime.split(" ")[1].slice(0, 5) + " - " + nextTimeInterval(prediction.datetime.split(" ")[1].slice(0, 2))}</Typography>
                   <Chip
                     label={prediction.prediction.toFixed(4)}
                     sx={{ backgroundColor: getPredictionColor(prediction.prediction) }}
@@ -103,3 +103,7 @@ function PrognoseCard({ id, predictions, loading }: ProgniseCardProps) {
 }
 
 export default PrognoseCard;
+function elif(arg0: boolean) {
+  throw new Error("Function not implemented.");
+}
+

--- a/src/utils/dateCheckers.ts
+++ b/src/utils/dateCheckers.ts
@@ -14,3 +14,13 @@ export const isToday = (datetime: string): boolean => {
 
     return givenDate.getDate() == today.getDate();
 };
+
+export const nextTimeInterval = (time: string): string => {
+  const timeMap: { [key: string]: string } = {
+    "00": "06:00",
+    "06": "12:00",
+    "12": "18:00",
+    "18": "00:00"
+  };
+  return timeMap[time];
+};


### PR DESCRIPTION
Endret prognose statusen til å vise prediksjon i det aktuelle tidsrommet istedenfor bare et tidspunkt.

![Screenshot 2024-10-16 at 16 30 05](https://github.com/user-attachments/assets/392b1fa7-8a38-459c-9941-4920d0cbf41d)
