### PR TITLE
Add training parameters

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -26,3 +26,7 @@ export const fetchWeatherData = (lat: number, lon: number) => {
 export const fetchPassabillity = (id: number) => {
   return apiClient.get(`/getCurrentPassability/${id}`);
 };
+
+export const fetchTrainingParameters = () => {
+  return apiClient.get("getTrainingParameters");
+};

--- a/src/components/MountainPassCard.tsx
+++ b/src/components/MountainPassCard.tsx
@@ -13,17 +13,22 @@ import PrognoseCard from "./PrognoseCard";
 import { Dispatch, SetStateAction } from "react";
 import { fetchPrediction } from "../api/api";
 import useFetch from "../hooks/useFetch";
+import { parameters } from "../types/PredictionTypes";
 
 interface MountainPassCardProps {
   data: MountainPassData;
   selectPass: Dispatch<SetStateAction<MountainPassData | null>>;
   selectedPass: MountainPassData | null;
+  parameters: parameters;
+  parametersLoading: boolean;
 }
 
 function MountainPassCard({
   data,
   selectPass,
   selectedPass,
+  parameters,
+  parametersLoading,
 }: MountainPassCardProps) {
   const isOpen = selectedPass?.properties.id === data.properties.id;
   const handleCardClick = () => {
@@ -121,6 +126,8 @@ function MountainPassCard({
           id={data.properties.id}
           predictions={prediction}
           loading={predictionLoading}
+          parameters={parameters}
+          parametersLoading={parametersLoading}
         />
       </Collapse>
     </Card>

--- a/src/components/MountainpassList.tsx
+++ b/src/components/MountainpassList.tsx
@@ -1,3 +1,5 @@
+import { fetchTrainingParameters } from "../api/api";
+import useFetch from "../hooks/useFetch";
 import { MountainPassData } from "../types/mountainPassTypes";
 import MountainPassCard from "./MountainPassCard";
 
@@ -14,14 +16,29 @@ function MountainPassList({
   selectedPass,
   setSelectedPass,
 }: MountainPassListProps) {
+  const {
+    data: parameters,
+    error: parametersError,
+    loading: parametersLoading,
+  } = useFetch(fetchTrainingParameters);
+
   return (
-    <nav style={{position: "relative", maxHeight: "94vh", overflowY: "auto", overflowX: "hidden"}}>
+    <nav
+      style={{
+        position: "relative",
+        maxHeight: "94vh",
+        overflowY: "auto",
+        overflowX: "hidden",
+      }}
+    >
       {mountainPasses.map((mountainPassData: MountainPassData) => (
         <MountainPassCard
           data={mountainPassData}
           key={mountainPassData.properties.id}
           selectPass={setSelectedPass}
           selectedPass={selectedPass}
+          parameters={parameters}
+          parametersLoading={parametersLoading}
         />
       ))}
     </nav>

--- a/src/components/MountainpassList.tsx
+++ b/src/components/MountainpassList.tsx
@@ -1,6 +1,7 @@
 import { fetchTrainingParameters } from "../api/api";
 import useFetch from "../hooks/useFetch";
 import { MountainPassData } from "../types/mountainPassTypes";
+import { parameters } from "../types/PredictionTypes";
 import MountainPassCard from "./MountainPassCard";
 
 interface MountainPassListProps {
@@ -9,19 +10,17 @@ interface MountainPassListProps {
   setSelectedPass: React.Dispatch<
     React.SetStateAction<MountainPassData | null>
   >;
+  parameters: parameters;
+  parametersLoading: boolean;
 }
 
 function MountainPassList({
   mountainPasses,
   selectedPass,
   setSelectedPass,
+  parameters,
+  parametersLoading,
 }: MountainPassListProps) {
-  const {
-    data: parameters,
-    error: parametersError,
-    loading: parametersLoading,
-  } = useFetch(fetchTrainingParameters);
-
   return (
     <nav
       style={{

--- a/src/components/PrognoseCard.tsx
+++ b/src/components/PrognoseCard.tsx
@@ -1,7 +1,7 @@
 import { Divider, Typography, Stack, Chip, Skeleton } from "@mui/material";
-import { predictions } from "../types/PredictionTypes";
+import { parameters, predictions } from "../types/PredictionTypes";
 import { isToday, isTomorrow, nextTimeInterval } from "../utils/dateCheckers";
-import LaunchOutlinedIcon from '@mui/icons-material/LaunchOutlined';
+import LaunchOutlinedIcon from "@mui/icons-material/LaunchOutlined";
 
 const LAV = 0.2;
 const MEDIUM = 0.5;
@@ -10,6 +10,8 @@ interface ProgniseCardProps {
   id: number;
   predictions: predictions[];
   loading: boolean;
+  parameters: parameters;
+  parametersLoading: boolean;
 }
 
 const getPredictionColor = (prediction: number): string => {
@@ -27,20 +29,39 @@ interface IdToName {
 }
 
 const mountainPassIdNames: IdToName = {
-  91192878: "de11iq8bwnzlsb",     // Dovrefjell
-  638645987: "fdyg4nqolil1ce",    // Saltfjellet
-  915906244: "de11hkvh6x7uof",    // Haukelifjellet
-  761980521: "ee11ix6s6nrb4e",    // Hol - Aurland
-  81833493: "ee11iyx9l80zkc",     // Hardangervidda
-  79089974: "de11ikylzarcwb",     // Aurlandsfjellet
-  91141932: "fe11ivb8k05j4c"      // Geiranger - Langvatn
+  91192878: "de11iq8bwnzlsb", // Dovrefjell
+  638645987: "fdyg4nqolil1ce", // Saltfjellet
+  915906244: "de11hkvh6x7uof", // Haukelifjellet
+  761980521: "ee11ix6s6nrb4e", // Hol - Aurland
+  81833493: "ee11iyx9l80zkc", // Hardangervidda
+  79089974: "de11ikylzarcwb", // Aurlandsfjellet
+  91141932: "fe11ivb8k05j4c", // Geiranger - Langvatn
 };
 
-function PrognoseCard({ id, predictions, loading }: ProgniseCardProps) {
-
+function PrognoseCard({
+  id,
+  predictions,
+  loading,
+  parameters,
+  parametersLoading,
+}: ProgniseCardProps) {
   return (
     <Stack spacing={2}>
-      <Typography>Risiko for stenging på grunn av vær</Typography>
+      <Typography>
+        Risiko for stenging av fjellovergangen på grunn av vær
+      </Typography>
+
+      <Typography>
+        Følgende parameter har blitt brukt i denne prognosen
+      </Typography>
+
+      {parametersLoading ? (
+        <Skeleton />
+      ) : (
+        parameters.inFeatures.map((parameter: string) => (
+          <Chip label={parameter} />
+        ))
+      )}
 
       <Typography
         component="a"
@@ -70,13 +91,23 @@ function PrognoseCard({ id, predictions, loading }: ProgniseCardProps) {
             if (isToday(prediction.datetime)) {
               return (
                 <Stack key={index} direction={"row"} spacing={7}>
-                  <Typography>{prediction.datetime.split(" ")[1].slice(0, 5) + " - " + nextTimeInterval(prediction.datetime.split(" ")[1].slice(0, 2))}</Typography>
+                  <Typography>
+                    {prediction.datetime.split(" ")[1].slice(0, 5) +
+                      " - " +
+                      nextTimeInterval(
+                        prediction.datetime.split(" ")[1].slice(0, 2)
+                      )}
+                  </Typography>
                   <Chip
                     label={prediction.prediction.toFixed(4)}
-                    sx={{ backgroundColor: getPredictionColor(prediction.prediction) }}
+                    sx={{
+                      backgroundColor: getPredictionColor(
+                        prediction.prediction
+                      ),
+                    }}
                   />
                 </Stack>
-              )
+              );
             }
           })}
 
@@ -88,10 +119,14 @@ function PrognoseCard({ id, predictions, loading }: ProgniseCardProps) {
                   <Typography>{prediction.datetime.split(" ")[1]}</Typography>
                   <Chip
                     label={prediction.prediction.toFixed(4)}
-                    sx={{ backgroundColor: getPredictionColor(prediction.prediction) }}
+                    sx={{
+                      backgroundColor: getPredictionColor(
+                        prediction.prediction
+                      ),
+                    }}
                   />
                 </Stack>
-              )
+              );
             }
           })}
         </>
@@ -106,4 +141,3 @@ export default PrognoseCard;
 function elif(arg0: boolean) {
   throw new Error("Function not implemented.");
 }
-

--- a/src/components/PrognoseCard.tsx
+++ b/src/components/PrognoseCard.tsx
@@ -55,13 +55,15 @@ function PrognoseCard({
         Følgende parameter har blitt brukt i denne prognosen
       </Typography>
 
-      {parametersLoading ? (
-        <Skeleton />
-      ) : (
-        parameters.inFeatures.map((parameter: string) => (
-          <Chip label={parameter} />
-        ))
-      )}
+      <Stack direction={"row"} spacing={1}>
+        {parametersLoading ? (
+          <Skeleton />
+        ) : (
+          parameters.inFeatures.map((parameter: string) => (
+            <Chip label={parameter.replace(/_|mean/g, " ").trim()} />
+          ))
+        )}
+      </Stack>
 
       <Typography
         component="a"

--- a/src/components/PrognoseCard.tsx
+++ b/src/components/PrognoseCard.tsx
@@ -2,6 +2,7 @@ import { Divider, Typography, Stack, Chip, Skeleton } from "@mui/material";
 import { parameters, predictions } from "../types/PredictionTypes";
 import { isToday, isTomorrow, nextTimeInterval } from "../utils/dateCheckers";
 import LaunchOutlinedIcon from "@mui/icons-material/LaunchOutlined";
+import { wrap } from "module";
 
 const LAV = 0.2;
 const MEDIUM = 0.5;
@@ -51,11 +52,11 @@ function PrognoseCard({
         Risiko for stenging av fjellovergangen på grunn av vær
       </Typography>
 
-      <Typography>
-        Følgende parameter har blitt brukt i denne prognosen
+      <Typography fontStyle="italic">
+        Følgende parameter har blitt brukt i denne prognosen:
       </Typography>
 
-      <Stack direction={"row"} spacing={1}>
+      <Stack direction={"row"} spacing={1} useFlexGap flexWrap="wrap">
         {parametersLoading ? (
           <Skeleton />
         ) : (

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -37,12 +37,6 @@ function MapPage() {
     loading: loadingFjelloverganger,
   } = useFetch(fetchAllMountainPasses, buildIndividualGeoJson);
 
-  const {
-    data: parameters,
-    error: parametersError,
-    loading: parametersLoading,
-  } = useFetch(fetchTrainingParameters);
-
   const [showAll, setShowAll] = useState<boolean>(true);
 
   const [viewState, setViewState] = useState<ViewState>(initialViewState);

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -8,7 +8,11 @@ import CssBaseline from "@mui/material/CssBaseline";
 
 import { WeatherData } from "../types/dataTypes";
 
-import { fetchAllMountainPasses, fetchWeatherData } from "../api/api";
+import {
+  fetchAllMountainPasses,
+  fetchTrainingParameters,
+  fetchWeatherData,
+} from "../api/api";
 import useFetch from "../hooks/useFetch";
 import { buildIndividualGeoJson } from "../utils/buildGeoJson";
 
@@ -32,6 +36,12 @@ function MapPage() {
     error: geoError,
     loading: loadingFjelloverganger,
   } = useFetch(fetchAllMountainPasses, buildIndividualGeoJson);
+
+  const {
+    data: parameters,
+    error: parametersError,
+    loading: parametersLoading,
+  } = useFetch(fetchTrainingParameters);
 
   const [showAll, setShowAll] = useState<boolean>(true);
 

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -37,6 +37,12 @@ function MapPage() {
     loading: loadingFjelloverganger,
   } = useFetch(fetchAllMountainPasses, buildIndividualGeoJson);
 
+  const {
+    data: parameters,
+    error: parametersError,
+    loading: parametersLoading,
+  } = useFetch(fetchTrainingParameters);
+
   const [showAll, setShowAll] = useState<boolean>(true);
 
   const [viewState, setViewState] = useState<ViewState>(initialViewState);
@@ -124,6 +130,8 @@ function MapPage() {
               mountainPasses={individualGeojsons}
               selectedPass={selectedPass}
               setSelectedPass={setSelectedPass}
+              parameters={parameters}
+              parametersLoading={parametersLoading}
             />
           )}
         </div>

--- a/src/types/PredictionTypes.ts
+++ b/src/types/PredictionTypes.ts
@@ -3,3 +3,7 @@ export type predictions = {
   prediction: number;
   prediction_time: string;
 };
+
+export type parameters = {
+  inFeatures: string[];
+};


### PR DESCRIPTION
Lagt til prognose features i `prognoseCard`.
- Henter i map-page for å minimere loadingtid.
- bør vurderes å flyttes til en useContext for å slippe prop-drilling, men det er en annen PR.

![image](https://github.com/user-attachments/assets/e09cc903-f7d5-414c-9bc6-8893065f4b27)
